### PR TITLE
fix SyntaxError when no cacheops library installed

### DIFF
--- a/wagtail_meilisearch/backend.py
+++ b/wagtail_meilisearch/backend.py
@@ -29,10 +29,9 @@ from .settings import STOP_WORDS
 
 try:
     from cacheops import invalidate_model
-except ImportError:
-    pass
-else:
     USING_CACHEOPS = True
+except ImportError:
+    USING_CACHEOPS = False
 
 
 AUTOCOMPLETE_SUFFIX = '_ngrams'


### PR DESCRIPTION
Hi Andy!

Thanks for the library, it's neat!

Here is a small fix for a bug that reveals when no cacheops library is installed.