### PR TITLE
Improve count and search performance using `/multi-search`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = [
 python = "^3.8"
 
 arrow = "^1.2.3"
-meilisearch = "^0.25.0"
+meilisearch = "^0.30.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/wagtail_meilisearch/backend.py
+++ b/wagtail_meilisearch/backend.py
@@ -433,7 +433,6 @@ class MeiliSearchResults(BaseSearchResults):
                     'indexUid': index_uid,
                     'q': terms,
                     **self.backend.search_params,
-                    'limit': 20,
                 }
                 for index_uid in models_boosts
             ])['results']


### PR DESCRIPTION
Fixes #4.

In the case of the project I am testing wagtail-meilisearch on, search is **2× faster** using this pull request.
It still takes 3 s instead of 6 s, but that's an improvement.

EDIT: Now **3× faster**, it takes 2 s instead of 6 s, in my case.

The remaining bottleneck comes from the way we apply fields boosts. We fetch all results, then adjust the ranking in Python to finally get only one page of results.
Unfortunately, I could not find a way to improve this, since Meilisearch does not support attribute boosting yet.