### PR TITLE
Added `get_key` method to MeiliSearchModelIndex

### DIFF
--- a/src/wagtail_meilisearch/index.py
+++ b/src/wagtail_meilisearch/index.py
@@ -224,6 +224,14 @@ class MeiliSearchModelIndex:
 
         self.label = label = model._meta.label.replace(".", "-")
         return label
+    
+    def get_key(self) -> str:
+        """Get the unique key for this index
+    
+        Returns:
+            str: This index's unique key
+        """
+        return self.label
 
     def _rebuild(self) -> None:
         """Rebuild the index by deleting and recreating it.


### PR DESCRIPTION
the current release does not work with wagtail 7.x, since wagtail 7.x requires search backends to have the `get_key` method which returns a unique label

this PR adds that method

### trace from using the current release
``` bash
  File "/Users/azan.ali/playground/bakerydemo/.venv/lib/python3.13/site-packages/modelsearch/management/commands/rebuild_modelsearch_index.py", line 41, in group_models_by_index
    index_key = index.get_key()
                ^^^^^^^^^^^^^
AttributeError: 'MeiliSearchModelIndex' object has no attribute 'get_key'
❯ wagtail --version
You are using Wagtail 7.2.1
❯ pip show wagtail-meilisearch
Name: wagtail-meilisearch
Version: 1.0.0
Summary: A MeiliSearch backend for Wagatil
Home-page: 
Author: Hactar
Author-email: Hactar <systems@hactar.is>
```

